### PR TITLE
menu: fix "air" custom click handling

### DIFF
--- a/cirrus-bungeecord/src/main/java/dev/simplix/cirrus/bungeecord/protocolize/ProtocolizeMenuBuilder.java
+++ b/cirrus-bungeecord/src/main/java/dev/simplix/cirrus/bungeecord/protocolize/ProtocolizeMenuBuilder.java
@@ -142,9 +142,6 @@ public class ProtocolizeMenuBuilder implements MenuBuilder {
             if (inventoryClick.player() == null) {
                 return;
             }
-            if (inventoryClick.clickedItem() == null) {
-                return;
-            }
             Inventory i = inventoryClick.inventory();
             if (i == null) {
                 return;

--- a/cirrus-common/src/main/java/dev/simplix/cirrus/common/model/Click.java
+++ b/cirrus-common/src/main/java/dev/simplix/cirrus/common/model/Click.java
@@ -6,6 +6,9 @@ import dev.simplix.cirrus.common.business.PlayerWrapper;
 import dev.simplix.cirrus.common.menu.Menu;
 import dev.simplix.protocolize.api.ClickType;
 import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
 import lombok.NonNull;
 
 /**
@@ -21,7 +24,7 @@ public class Click {
     public Click(
             @NonNull ClickType clickType,
             @NonNull Menu clickedMenu,
-            @NonNull InventoryMenuItemWrapper clickedItem,
+            @Nullable InventoryMenuItemWrapper clickedItem,
             int slot) {
         this.clickType = clickType;
         this.clickedMenu = clickedMenu;

--- a/cirrus-velocity/src/main/java/dev/simplix/cirrus/velocity/protocolize/ProtocolizeMenuBuilder.java
+++ b/cirrus-velocity/src/main/java/dev/simplix/cirrus/velocity/protocolize/ProtocolizeMenuBuilder.java
@@ -111,9 +111,6 @@ public class ProtocolizeMenuBuilder implements MenuBuilder {
             if (inventoryClick.player()==null) {
                 return;
             }
-            if (inventoryClick.clickedItem()==null) {
-                return;
-            }
             Inventory i = inventoryClick.inventory();
             if (i==null) {
                 return;


### PR DESCRIPTION
This fixes the onClick handler so to allow "empty" fields to correctly
trigger the customActionHandler set on a Cirrus menu.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***

This also addresses a compilation error, I was getting about the `cirrus-spigot` module, let me know if this should go into a separate PR:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project cirrus-spigot: Compilation failure: Compilation failure:
[ERROR] REDACTED/Cirrus/cirrus-spigot/src/main/java/dev/simplix/cirrus/spigot/util/OtherModuleProvider.java:[38,5] method does not override or implement a method from a supertype
[ERROR] REDACTED/Cirrus/cirrus-spigot/src/main/java/dev/simplix/cirrus/spigot/util/OtherModuleProvider.java:[43,5] method does not override or implement a method from a supertype
[ERROR] -> [Help 1]
```

***

I have only tested this change on Waterfall with a basic `customActionHandler` and I successfully got `CLICKED ITEM: null` in the chat:
```
customActionHandler(click -> {
    click.player().sendMessage("CLICKED ITEM: " + click.clickedItem());
    return null;
});
```

***

Resolves #14