### PR TITLE
Change velocity repository url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         </repository>
         <repository>
             <id>velocity</id>
-            <url>https://repo.velocitypowered.com/snapshots/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>spigot-repo</id>


### PR DESCRIPTION
":meowbox: Hello @Plugin Developer,

We are changing important repository URLs to https://repo.papermc.io/repository/maven-public/. Please replace all references to the following repositorie URLs in your projects:

:dot_red: https://papermc.io/repo/repository/maven-public/
:dot_red: https://nexus.velocitypowered.com/repository/maven-public/
:dot_red: https://repo.velocitypowered.com/snapshots/

Replace them with https://repo.papermc.io/repository/maven-public/ - the other repository endpoints are deprecated and will be taken offline in the future. " - PaperMC team